### PR TITLE
기증신청서에 이벤트의 레퍼런스를 기록

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+  - GET /redirect route 추가
+
 v0.5.4    Fri, 04 May 2018 20:43:11 +0900
   - Set default config file in docker image
 

--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
   - GET /redirect route 추가
+  - 이벤트를 통한 기증임을 추적하는 기능 추가 (#107)
 
 v0.5.4    Fri, 04 May 2018 20:43:11 +0900
   - Set default config file in docker image

--- a/RELEASE-TODO.md
+++ b/RELEASE-TODO.md
@@ -1,3 +1,6 @@
+    $ mysql -u opencloset -p opencloset < OpenCloset-Schema/db/alter/140-event.sql
+    $ closetpan OpenCloset::Schema    # 0.057
+
 v0.5.4
 
 v0.5.3

--- a/cpanfile
+++ b/cpanfile
@@ -21,4 +21,4 @@ requires 'Try::Tiny';
 # cpan.theopencloset.net
 requires 'OpenCloset::Common',          'v0.1.1';
 requires 'OpenCloset::Plugin::Helpers', 'v0.0.24';
-requires 'OpenCloset::Schema',          '0.047';
+requires 'OpenCloset::Schema',          '0.057';

--- a/lib/OpenCloset/Donation.pm
+++ b/lib/OpenCloset/Donation.pm
@@ -62,6 +62,9 @@ sub _public_routes {
     my $self = shift;
     my $r    = $self->routes;
 
+    # will redirect to root#index
+    $r->get('/redirect')->to('root#redirect');
+
     $r->get('/')->to('root#index')->name('home');
     $r->get('/guide1')->to('root#guide1');
     $r->get('/guide2')->to('root#guide2');

--- a/lib/OpenCloset/Donation/Controller/Root.pm
+++ b/lib/OpenCloset/Donation/Controller/Root.pm
@@ -17,7 +17,7 @@ has schema => sub { shift->app->schema };
 
 =cut
 
-sub home {
+sub index {
 }
 
 =head2 guide1

--- a/lib/OpenCloset/Donation/Controller/Root.pm
+++ b/lib/OpenCloset/Donation/Controller/Root.pm
@@ -1,6 +1,7 @@
 package OpenCloset::Donation::Controller::Root;
 use Mojo::Base 'Mojolicious::Controller';
 
+use DateTime;
 use Email::Sender::Simple qw(sendmail);
 use Email::Sender::Transport::SMTP qw();
 use Email::Simple;
@@ -64,6 +65,16 @@ sub guide2 {
 =cut
 
 sub add {
+    my $self = shift;
+
+    my $today = DateTime->today(time_zone => $self->config->{timezone})->ymd;
+    my $event_id = $self->session('event');
+
+    my $event = $self->schema->resultset('Event')->find({
+        id => $event_id
+    });
+
+    $self->render(event => $event);
 }
 
 =head2 create
@@ -92,6 +103,7 @@ sub create {
     $v->optional('terms');
     $v->optional('talent-donation');
     $v->optional('talent');
+    $v->optional('event_id');
 
     if ( $v->has_error ) {
         my $failed = $v->failed;
@@ -113,6 +125,7 @@ sub create {
     my $terms           = $v->param('terms');
     my $talent_donation = $v->param('talent-donation');
     my $talent          = $v->param('talent');
+    my $event_id        = $v->param('event_id');
 
     $phone =~ s/-//g;
     my @categories = qw(자켓 바지/스커트 셔츠/블라우스 구두 타이/벨트 코트 기타);
@@ -137,7 +150,8 @@ sub create {
             quantity        => $quantity,
             terms           => $terms,
             talent_donation => $talent_donation,
-            talent          => $talent
+            talent          => $talent,
+            event_id        => $event_id,
         }
     );
 

--- a/lib/OpenCloset/Donation/Controller/Root.pm
+++ b/lib/OpenCloset/Donation/Controller/Root.pm
@@ -10,6 +10,24 @@ has schema => sub { shift->app->schema };
 
 =head1 METHODS
 
+=head2 redirect
+
+    GET /redirect?event=1
+
+=cut
+
+sub redirect {
+    my $self = shift;
+
+    my $event_id = $self->param('event_id');
+    if ($event_id) {
+        my $event = $self->schema->resultset('Event')->find({ id => $event_id });
+        $self->session(event => $event_id) if $event;
+    }
+
+    $self->redirect_to('home');
+}
+
 =head2 index
 
     # home

--- a/script/add_event.pl
+++ b/script/add_event.pl
@@ -1,0 +1,117 @@
+use utf8;
+use strict;
+use warnings;
+use DateTime;
+use Encode qw/decode_utf8/;
+use Getopt::Long;
+use Pod::Usage;
+
+use OpenCloset::Schema;
+
+binmode STDOUT, ':encoding(UTF-8)';
+binmode STDERR, ':encoding(UTF-8)';
+
+my $schema = OpenCloset::Schema->connect(
+    {
+        dsn               => "dbi:mysql:opencloset:127.0.0.1",
+        user              => 'opencloset',
+        password          => 'opencloset',
+        quote_char        => q{`},
+        mysql_enable_utf8 => 1,
+        on_connect_do     => 'SET NAMES utf8',
+        RaiseError        => 1,
+        AutoCommit        => 1,
+    }
+);
+
+my %options;
+GetOptions(
+    \%options,
+    "--help",
+    "--name|n=s",
+    "--desc|d=s",
+    "--sponsor|s=s",
+    "--year|y=i",
+    "--nth=i",
+    "--start_date|S=s",
+    "--end_date|E=s"
+);
+
+run( \%options, @ARGV );
+
+sub run {
+    my ( $opts ) = @_;
+    pod2usage(0) if $opts->{help};
+    pod2usage(0) unless $opts->{name};
+
+    my $name       = decode_utf8($opts->{name});
+    my $desc       = decode_utf8($opts->{desc} || '');
+    my $sponsor    = decode_utf8($opts->{sponsor} || '');
+    my $year       = $opts->{year} || (localtime)[5] + 1900; # this year
+    my $nth        = $opts->{nth} || 1;
+    my $start_date = $opts->{start_date} || DateTime->today(time_zone => 'Asia/Seoul')->ymd;
+    my $end_date   = $opts->{end_date};
+
+    # prevent Use of uninitialized value warn
+    my $date_s = $start_date || '';
+    my $date_e = $end_date   || '';
+
+    printf(<<EOL, $name, $desc, $sponsor, $year, $nth, $date_s, $date_e);
+name       : %s
+desc       : %s
+sponsor    : %s
+year       : %d
+nth        : %d
+start_date : %s
+end_date   : %s
+
+EOL
+
+    print "Continue? [Y/n] ";
+    my $answer = <STDIN>;
+    chomp $answer;
+    $answer = 'y' if $answer eq '';
+    unless ($answer =~ m/y/i) {
+        print "aborted\n";
+        exit;
+    }
+
+    my $event = $schema->resultset('Event')->create({
+        name       => $name,
+        desc       => $desc,
+        sponsor    => $sponsor,
+        year       => $year,
+        nth        => $nth,
+        start_date => $start_date,
+        end_date   => $end_date
+    });
+
+    die "Failed to create a new event" unless $event;
+
+    print "\n[OK] a new event created\n\n";
+    print "$event\n";
+};
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+add_event.pl - insert a new row to event table
+
+=head1 SYNOPSIS
+
+    $ script/add_event.pl
+      * is required
+
+        --help|h          print this help.
+      * --name|n          name of event.
+        --desc|d          description.
+        --sponsor         sponsor name
+        --year|y          if not present, this year is default.
+        --nth             nth rounds.
+        --start_date|S    if not present, today. TZ: Asia/Seoul
+        --end_date|E
+
+=cut

--- a/templates/form/form.html.ep
+++ b/templates/form/form.html.ep
@@ -27,6 +27,14 @@
     <a class="btn btn-default btn-sm" href="<%= url_for('user.donations', id => $user->id) %>">
       기부현황
     </a>
+    % if (my $event = $form->event) {
+      <span class="label label-success">
+        % if ($event->sponsor) {
+          %= $event->sponsor
+        % }
+        %= $event->name
+      </span>
+    % }
     <p class="text-muted">
       <small>
         <%= $user->donations->count %> 건의 기부와

--- a/templates/root/add.html.ep
+++ b/templates/root/add.html.ep
@@ -291,6 +291,20 @@
           <textarea class="form-control" name="talent"></textarea>
         </div>
       </div>
+
+      <hr>
+
+      <div class="form-group">
+        % if ($event) {
+          <div class="checkbox">
+            <label>
+              <input name="event_id" type="checkbox" value="<%= $event->id %>" checked>
+              <%= $event->name %> 기증캠페인에 참여하는 임직원이십니까?
+              <small>(해당하는 경우만 체크해주세요.)</small>
+            </label>
+          </div>
+        % }
+      </div>
     </fieldset>
 
     <button class="btn btn-danger" type="reset">다시 입력하겠습니다</button>


### PR DESCRIPTION
#107 

# event 의 추가

이벤트를 추가해야 하는데 옷장지기가 할 수 있는 방법이 없습니다.
궁극적으로는 이벤트를 관리할 수 있는 web UI 가 있어야 합니다.

-   이름
-   설명
-   스폰서
-   연도
-   회차
-   시작일
-   종료일

을 알려주시면 그 데이터를 바탕으로 이벤트를 추가해주어야 합니다.

    $ perl script/add_event.pl -n '열린그룹 정장기증' -d '열린그룹에서 진행하는 캠페인' --sponsor '열린옷장' -S '2018-11-01' -E '2018-12-31'
    name       : 열린그룹 정장기증
    desc       : 열린그룹에서 진행하는 캠페인
    sponsor    : 열린옷장
    year       : 2018
    nth        : 1
    start_date : 2018-11-01
    end_date   : 2018-12-31
    
    Continue? [Y/n] 
    
    [OK] a new event created
    
    ------------------------------
             id: 1
            nth: 1
           desc: 열린그룹에서 진행하는 캠페인
           name: 열린그룹 정장기증
           year: 2018
        sponsor: 열린옷장
       end_date: 2018-12-31
     start_date: 2018-11-01
    create_date: 2018-10-21 14:01:06
    update_date: 2018-10-21 14:01:06
    ------------------------------


# GET /redirect?event_id=xx

추가하고 나면 id 를 가지고 이벤트(캠페인) 전용 URL 을 전달합니다.
<https://donation.theopencloset.net/redirect?event_id=1>

이 주소로 유입된 사용자에게는 기증 신청서에 아래와 같은 내용이 나타납니다.

<img width="1175" alt="2018-10-21 2 05 21" src="https://user-images.githubusercontent.com/170528/47263352-f16be680-d53a-11e8-8f25-b611ea2e7da7.png">

<img width="433" alt="2018-10-21 2 08 21" src="https://user-images.githubusercontent.com/170528/47263354-f892f480-d53a-11e8-9175-39fae1f49e81.png">

